### PR TITLE
Resolved non varname bento warnings

### DIFF
--- a/measure
+++ b/measure
@@ -36,7 +36,8 @@ class Hey(Measure):
         self.print_measure_error(err, ST_FAILED)
         try:
             self.proc.terminate()
-        except:
+        # No sec below as process should be terminated by sys.exit if the above fails
+        except: # nosec
             pass
         sys.exit(3)
 


### PR DESCRIPTION
Bento Output:

```
bandit try-except-pass https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html
     > measure_driver.py:39                                                           
     ╷                                                                                
   39│   except:                                                                      
     ╵
     = Try, Except, Pass detected.

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > measure_driver.py:118
     ╷
  118│   l = line.decode().strip()
     ╵
     = ambiguous variable name 'l'

flake8 ambiguous-variable-name https://lintlyci.github.io/Flake8Rules/rules/E741.html
     > measure_driver.py:156
     ╷
  156│   l = Hey(VERSION, DESC, HAS_CANCEL, PROGRESS_INTERVAL)
     ╵
     = ambiguous variable name 'l'
```